### PR TITLE
Add Fan Control (incl. Rotation Speed, WindFree mode) and Humidity Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,23 @@ Homebridge plugin for controlling Samsung Air Conditioner using the [smartthings
      - Make sure you select all scopes in the devices section.
      - Make sure you can see the devices you want to use for the current user, in the ["My Devices" tab](https://account.smartthings.com/).
 5. Copy the token and paste it in the token property of the plugin (config.json).
-6. [Optional] In case your smartthings account returns the temperature in Fahrenheit, set the Temperature unit config property to F and also make sure that your device in HomeKit is also set to Fahrenheit. Otherwise leave the default value for Temperature unit.
+
+## Optional Settings
+
+- In case your smartthings account returns the temperature in Fahrenheit, set the Temperature unit config property to F and also make sure that your device in HomeKit is also set to Fahrenheit. Otherwise leave the default value for Temperature unit.
+- Enable showing the humidity value if desired: The value will be shown as 0% as long as the device is turned off or just started. This is a limitation of the smartthings api.
+- If your Air conditioners support the WindFree option, enable the `windFreeSupported` option (config.json). This allows you to enable the WindFree mode through the "oscillation" settings of the _fan_ while the normal oscillation (fixed vs all directions) is available through the Air conditioner in Apple Home. This changes makes it easier to enable the WindFree mode if the fan and Air conditioner settings are grouped in Apple Home (which is the default if added through Homebridge).
 
 ## Features
 - Import all AC devices in your smartthings account
 - Turning AC on and off
 - Getting and setting target temperature
 - Getting current temperature
-- Getting and setting mode
+- Getting and setting AC mode
+- Turning the fan on and off
+- Getting and setting fan operation mode (manual / automatic)
+- Getting and setting rotation speed of the fan 
+  - A target fan speed of automatic will report with a rotation speed of 0% as the actual rotation speed cannot be determined.
+- Getting and setting oscillation mode
+- Getting and setting WindFree mode (if supported)
+- Getting current humidity (if enabled)

--- a/config.schema.json
+++ b/config.schema.json
@@ -22,6 +22,12 @@
         "type": "string",
         "required": true,
         "default": "C"
+      },
+      "showHumidity": {
+        "title": "Show humidity values",
+        "type": "boolean",
+        "required": true,
+        "default": false
       }
     }
   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -28,6 +28,12 @@
         "type": "boolean",
         "required": true,
         "default": false
+      },
+      "windFreeSupported": {
+        "title": "Enable WindFree support",
+        "type": "boolean",
+        "required": true,
+        "default": false
       }
     }
   }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -51,19 +51,19 @@ export class SamsungACPlatformAccessory {
     this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .onGet(this.handleCurrentTemperatureGet.bind(this));
 
-    const threshholdProps = {
+    const temperatureProps = {
       minValue: 16,
       maxValue: 30,
       minStep: 1,
     };
 
     this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
-      .setProps(threshholdProps)
+      .setProps(temperatureProps)
       .onSet(this.handleCoolingTemperatureSet.bind(this))
       .onGet(this.handleCoolingTemperatureGet.bind(this));
 
     this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
-      .setProps(threshholdProps)
+      .setProps(temperatureProps)
       .onSet(this.handleCoolingTemperatureSet.bind(this))
       .onGet(this.handleHeatingTemperatureGet.bind(this));
   }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -184,7 +184,7 @@ export class SamsungACPlatformAccessory {
     SamsungAPI.getDeviceTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((temperature) => {
         if (this.accessory.context.temperatureUnit === 'F') {
-          temperature = this.toCelsius(temperature);
+          temperature = SamsungACPlatformAccessory.toCelsius(temperature);
         }
         this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
           .updateValue(temperature);
@@ -200,7 +200,7 @@ export class SamsungACPlatformAccessory {
     SamsungAPI.getDesiredTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((temperature) => {
         if (this.accessory.context.temperatureUnit === 'F') {
-          temperature = this.toCelsius(temperature);
+          temperature = SamsungACPlatformAccessory.toCelsius(temperature);
         }
         this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
           .updateValue(temperature);
@@ -217,7 +217,7 @@ export class SamsungACPlatformAccessory {
     SamsungAPI.getDesiredTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((temperature) => {
         if (this.accessory.context.temperatureUnit === 'F') {
-          temperature = this.toCelsius(temperature);
+          temperature = SamsungACPlatformAccessory.toCelsius(temperature);
         }
         this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
           .updateValue(temperature);
@@ -232,16 +232,16 @@ export class SamsungACPlatformAccessory {
   async handleCoolingTemperatureSet(temp) {
     // set this to a valid value for DesiredTemperature
     if (this.accessory.context.temperatureUnit === 'F') {
-      temp = this.toFahrenheit(temp);
+      temp = SamsungACPlatformAccessory.toFahrenheit(temp);
     }
     await SamsungAPI.setDesiredTemperature(this.accessory.context.device.deviceId, temp, this.accessory.context.token);
   }
 
-  private toCelsius(fTemperature) {
+  private static toCelsius(fTemperature) {
     return Math.round((5/9) * (fTemperature - 32));
   }
 
-  private toFahrenheit(cTemperature){
+  private static toFahrenheit(cTemperature){
     return Math.round((cTemperature * 1.8) + 32);
   }
 }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -4,7 +4,7 @@ import { SamsungAC } from './platform';
 import { SamsungAPI } from './samsungApi';
 
 export class SamsungACPlatformAccessory {
-  private service: Service;
+  private heaterCoolerService: Service;
 
   private states = {
     On: 'on',
@@ -31,24 +31,24 @@ export class SamsungACPlatformAccessory {
       .setCharacteristic(this.platform.Characteristic.Model, accessory.context.device.deviceTypeName)
       .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.device.deviceId);
 
-    this.service = this.accessory.getService(this.platform.Service.HeaterCooler)
+    this.heaterCoolerService = this.accessory.getService(this.platform.Service.HeaterCooler)
       || this.accessory.addService(this.platform.Service.HeaterCooler);
 
-    this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.label);
+    this.heaterCoolerService.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.label);
 
     // register handlers for the On/Off Characteristic
-    this.service.getCharacteristic(this.platform.Characteristic.Active)
+    this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.Active)
       .onSet(this.handleActiveSet.bind(this))
       .onGet(this.handleActiveGet.bind(this));
 
-    this.service.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
+    this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
       .onGet(this.handleCurrentHeaterCoolerStateGet.bind(this));
 
-    this.service.getCharacteristic(this.platform.Characteristic.TargetHeaterCoolerState)
+    this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.TargetHeaterCoolerState)
       .onGet(this.handleTargetHeaterCoolerStateGet.bind(this))
       .onSet(this.handleTargetHeaterCoolerStateSet.bind(this));
 
-    this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+    this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .onGet(this.handleCurrentTemperatureGet.bind(this));
 
     const threshholdProps = {
@@ -57,12 +57,12 @@ export class SamsungACPlatformAccessory {
       minStep: 1,
     };
 
-    this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
+    this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
       .setProps(threshholdProps)
       .onSet(this.handleCoolingTemperatureSet.bind(this))
       .onGet(this.handleCoolingTemperatureGet.bind(this));
 
-    this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+    this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .setProps(threshholdProps)
       .onSet(this.handleCoolingTemperatureSet.bind(this))
       .onGet(this.handleHeatingTemperatureGet.bind(this));
@@ -77,7 +77,7 @@ export class SamsungACPlatformAccessory {
     SamsungAPI.getDeviceStatus(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((status) => {
         currentValue = status === this.states.Off ? currentValue : this.platform.Characteristic.Active.ACTIVE;
-        this.service.getCharacteristic(this.platform.Characteristic.Active)
+        this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.Active)
           .updateValue(currentValue);
       }).catch((error) => {
         this.platform.log.warn(error);
@@ -118,7 +118,7 @@ export class SamsungACPlatformAccessory {
           }
         }
 
-        this.service.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
+        this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
           .updateValue(currentValue);
       }).catch((error) => {
         this.platform.log.warn(error);
@@ -148,7 +148,7 @@ export class SamsungACPlatformAccessory {
           }
         }
 
-        this.service.getCharacteristic(this.platform.Characteristic.TargetHeaterCoolerState)
+        this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.TargetHeaterCoolerState)
           .updateValue(currentValue);
       }).catch((error) => {
         this.platform.log.warn(error);
@@ -186,7 +186,7 @@ export class SamsungACPlatformAccessory {
         if (this.accessory.context.temperatureUnit === 'F') {
           temperature = this.toCelsius(temperature);
         }
-        this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+        this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
           .updateValue(temperature);
       }).catch((error) => {
         this.platform.log.warn(error);
@@ -202,7 +202,7 @@ export class SamsungACPlatformAccessory {
         if (this.accessory.context.temperatureUnit === 'F') {
           temperature = this.toCelsius(temperature);
         }
-        this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
+        this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
           .updateValue(temperature);
       }).catch((error) => {
         this.platform.log.warn(error);
@@ -219,7 +219,7 @@ export class SamsungACPlatformAccessory {
         if (this.accessory.context.temperatureUnit === 'F') {
           temperature = this.toCelsius(temperature);
         }
-        this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+        this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
           .updateValue(temperature);
       }).catch((error) => {
         this.platform.log.warn(error);

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -153,7 +153,7 @@ export class SamsungACPlatformAccessory {
   /**
    * Handle requests to get the current value of the "Active" characteristic of the Heater Cooler Service
    */
-  handleHeaterCoolerActiveGet() {
+  async handleHeaterCoolerActiveGet() {
     // set this to a valid value for Active
     let currentValue = this.platform.Characteristic.Active.INACTIVE;
     await SamsungAPI.getDeviceStatus(this.accessory.context.device.deviceId, this.accessory.context.token)
@@ -205,10 +205,10 @@ export class SamsungACPlatformAccessory {
   /**
    * Handle requests to get the current value of the "Current Heater-Cooler State" characteristic
    */
-  handleCurrentHeaterCoolerStateGet() {
+  async handleCurrentHeaterCoolerStateGet() {
     // set this to a valid value for CurrentHeaterCoolerState
-    let currentValue = this.platform.Characteristic.CurrentHeaterCoolerState.IDLE;
-    SamsungAPI.getDeviceMode(this.accessory.context.device.deviceId, this.accessory.context.token)
+    let currentValue = this.platform.Characteristic.CurrentHeaterCoolerState.IDLE; // also returned for "auto" mode
+    await SamsungAPI.getDeviceMode(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((deviceMode) => {
         switch (deviceMode) {
           case this.deviceMode.Dry:
@@ -239,10 +239,10 @@ export class SamsungACPlatformAccessory {
   /**
    * Handle requests to get the current value of the "Target Heater-Cooler State" characteristic
    */
-  handleTargetHeaterCoolerStateGet() {
+  async handleTargetHeaterCoolerStateGet() {
     // set this to a valid value for TargetHeaterCoolerState
     let currentValue = this.platform.Characteristic.TargetHeaterCoolerState.AUTO;
-    SamsungAPI.getDeviceMode(this.accessory.context.device.deviceId, this.accessory.context.token)
+    await SamsungAPI.getDeviceMode(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((deviceMode) => {
         switch (deviceMode) {
           case this.deviceMode.Dry:
@@ -309,54 +309,59 @@ export class SamsungACPlatformAccessory {
   /**
    * Handle requests to get the current value of the "Current Temperature" characteristic
    */
-  handleCurrentTemperatureGet() {
+  async handleCurrentTemperatureGet() {
     // set this to a valid value for CurrentTemperature
-    SamsungAPI.getDeviceTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
+    let currentValue = this.defaultTemperature;
+    await SamsungAPI.getDeviceTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((temperature) => {
         if (this.accessory.context.temperatureUnit === 'F') {
           temperature = SamsungACPlatformAccessory.toCelsius(temperature);
         }
+        currentValue = temperature;
         this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
           .updateValue(temperature);
       }).catch((error) => {
         this.platform.log.warn(error);
       });
 
-    return this.defaultTemperature;
+    return currentValue;
   }
 
-  handleCoolingTemperatureGet() {
+  async handleCoolingTemperatureGet() {
+    let currentValue = this.defaultTemperature;
     // get value for DesiredTemperature
-    SamsungAPI.getDesiredTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
+    await SamsungAPI.getDesiredTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((temperature) => {
         if (this.accessory.context.temperatureUnit === 'F') {
           temperature = SamsungACPlatformAccessory.toCelsius(temperature);
         }
+        currentValue = temperature;
         this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
           .updateValue(temperature);
+        return temperature;
       }).catch((error) => {
         this.platform.log.warn(error);
       });
 
-
-    return this.defaultTemperature;
+    return currentValue;
   }
 
-  handleHeatingTemperatureGet() {
+  async handleHeatingTemperatureGet() {
+    let currentValue = this.defaultTemperature;
     // get value for DesiredTemperature
-    SamsungAPI.getDesiredTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
+    await SamsungAPI.getDesiredTemperature(this.accessory.context.device.deviceId, this.accessory.context.token)
       .then((temperature) => {
         if (this.accessory.context.temperatureUnit === 'F') {
           temperature = SamsungACPlatformAccessory.toCelsius(temperature);
         }
+        currentValue = temperature;
         this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
           .updateValue(temperature);
       }).catch((error) => {
         this.platform.log.warn(error);
       });
 
-
-    return this.defaultTemperature;
+    return currentValue;
   }
 
   async handleCoolingTemperatureSet(temp) {

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -38,8 +38,8 @@ export class SamsungACPlatformAccessory {
 
     // register handlers for the On/Off Characteristic
     this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.Active)
-      .onSet(this.handleActiveSet.bind(this))
-      .onGet(this.handleActiveGet.bind(this));
+      .onSet(this.handleHeaterCoolerActiveSet.bind(this))
+      .onGet(this.handleHeaterCoolerActiveGet.bind(this));
 
     this.heaterCoolerService.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
       .onGet(this.handleCurrentHeaterCoolerStateGet.bind(this));
@@ -69,9 +69,9 @@ export class SamsungACPlatformAccessory {
   }
 
   /**
-   * Handle requests to get the current value of the "Active" characteristic
+   * Handle requests to get the current value of the "Active" characteristic of the Heater Cooler Service
    */
-  handleActiveGet() {
+  handleHeaterCoolerActiveGet() {
     // set this to a valid value for Active
     let currentValue = this.platform.Characteristic.Active.INACTIVE;
     SamsungAPI.getDeviceStatus(this.accessory.context.device.deviceId, this.accessory.context.token)
@@ -87,9 +87,9 @@ export class SamsungACPlatformAccessory {
   }
 
   /**
-   * Handle requests to set the "Active" characteristic
+   * Handle requests to set the "Active" characteristic of the Heater Cooler Service
    */
-  async handleActiveSet(value) {
+  async handleHeaterCoolerActiveSet(value) {
     const statusValue = value === 1 ? this.states.On : this.states.Off ;
     await SamsungAPI.setDeviceStatus(this.accessory.context.device.deviceId, statusValue, this.accessory.context.token);
   }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -5,6 +5,7 @@ import { SamsungAPI } from './samsungApi';
 
 export class SamsungACPlatformAccessory {
   private heaterCoolerService: Service;
+  private fanV2Service: Service;
   private humidityService: Service | undefined;
 
   private states = {
@@ -18,6 +19,19 @@ export class SamsungACPlatformAccessory {
     Dry: 'dry',
     Fan: 'wind',
     Auto: 'auto',
+  };
+
+  private fanMode = {
+    Auto: { name: 'auto', rotation: 0 },
+    Low: { name: 'low', rotation: 25 },
+    Medium: { name: 'medium', rotation: 50 },
+    High: { name: 'high', rotation: 75 },
+    Turbo: { name: 'turbo', rotation: 100 },
+  };
+
+  private swingMode = {
+    All: 'all',
+    Fixed: 'fixed',
   };
 
   private defaultTemperature = 21;
@@ -68,6 +82,42 @@ export class SamsungACPlatformAccessory {
       .setProps(temperatureProps)
       .onSet(this.handleCoolingTemperatureSet.bind(this))
       .onGet(this.handleHeatingTemperatureGet.bind(this));
+
+    /**
+     *  FanV2 Service
+     */
+    this.fanV2Service = this.accessory.getService(this.platform.Service.Fanv2)
+      || this.accessory.addService(this.platform.Service.Fanv2);
+
+    this.fanV2Service.getCharacteristic(this.platform.Characteristic.Active)
+      .onSet(this.handleFanActiveSet.bind(this))
+      .onGet(this.handleFanActiveGet.bind(this));
+
+    const rotationProps = {
+      minValue: 0,
+      maxValue: 100,
+      minStep: 25,
+    };
+
+    // register handlers for the Fan Rotation Speed Characteristic
+    this.fanV2Service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+      .setProps(rotationProps)
+      .onSet(this.handleRotationSpeedSet.bind(this))
+      .onGet(this.handleRotationSpeedGet.bind(this));
+
+    // register handlers for the Target Fan State Characteristic
+    this.fanV2Service.getCharacteristic(this.platform.Characteristic.CurrentFanState)
+      .onGet(this.handleFanActiveGet.bind(this));
+
+    // register handlers for the Target Fan State Characteristic
+    this.fanV2Service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+      .onSet(this.handleTargetFanStateSet.bind(this))
+      .onGet(this.handleTargetFanStateGet.bind(this));
+
+    // register handlers for the Fan Swing Mode Characteristic
+    this.fanV2Service.getCharacteristic(this.platform.Characteristic.SwingMode)
+      .onSet(this.handleSwingModeSet.bind(this))
+      .onGet(this.handleSwingModeGet.bind(this));
 
     /**
      *  Humidity Service if enabled
@@ -268,6 +318,236 @@ export class SamsungACPlatformAccessory {
       temp = SamsungACPlatformAccessory.toFahrenheit(temp);
     }
     await SamsungAPI.setDesiredTemperature(this.accessory.context.device.deviceId, temp, this.accessory.context.token);
+  }
+
+  /**
+   * Handle requests to get the current value of the "Active" characteristic of the Fan V2 Service
+   */
+  async handleFanActiveGet() {
+    // set this to a valid value for Active
+    let currentValue = this.platform.Characteristic.Active.INACTIVE;
+    await SamsungAPI.getDeviceStatus(this.accessory.context.device.deviceId, this.accessory.context.token)
+      .then((status) => {
+        if (status === this.states.On) {
+          currentValue = this.platform.Characteristic.Active.ACTIVE;
+        }
+
+        // The device status maps directly to the Active characteristic of the Fan service
+        this.fanV2Service.getCharacteristic(this.platform.Characteristic.Active)
+          .updateValue(currentValue);
+
+        this.fanV2Service.getCharacteristic(this.platform.Characteristic.CurrentFanState)
+          .updateValue(this.platform.Characteristic.CurrentFanState.INACTIVE);
+      }).catch((error) => {
+        this.platform.log.warn(error);
+      });
+
+    return currentValue;
+  }
+
+  /**
+   * Handle requests to set the "Active" characteristic of the Fan V2 Service
+   */
+  async handleFanActiveSet(value) {
+    let statusValue: string;
+    if (value === this.platform.Characteristic.Active.ACTIVE) {
+      statusValue = this.states.On;
+      this.handleFanActiveGet()
+        .then((activeModeFan) => {
+          if (activeModeFan === this.platform.Characteristic.Active.INACTIVE) {
+            return this.handleHeaterCoolerActiveGet();
+          }
+        }).then((activeModeAC) => {
+          if (activeModeAC === undefined) {
+          // The fan is already active and the previous Promise did not return a new Promise
+          // Nothing should be changed here, skipping the actions below
+            return;
+          } else if (activeModeAC === this.platform.Characteristic.Active.INACTIVE) {
+            SamsungAPI.setDeviceMode(this.accessory.context.device.deviceId, this.deviceMode.Fan, this.accessory.context.token);
+            // The fan will be set to "Low" and manual mode
+            this.fanV2Service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+              .updateValue(this.fanMode.Low.rotation);
+            this.fanV2Service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+              .updateValue(this.platform.Characteristic.TargetFanState.MANUAL);
+          } else {
+            this.handleRotationSpeedGet();
+          }
+        });
+      this.fanV2Service.getCharacteristic(this.platform.Characteristic.CurrentFanState)
+        .updateValue(this.platform.Characteristic.CurrentFanState.BLOWING_AIR);
+    } else {
+      statusValue = this.states.Off;
+      this.fanV2Service.getCharacteristic(this.platform.Characteristic.CurrentFanState)
+        .updateValue(this.platform.Characteristic.CurrentFanState.INACTIVE);
+    }
+
+    await SamsungAPI.setDeviceStatus(this.accessory.context.device.deviceId, statusValue, this.accessory.context.token);
+  }
+
+  /**
+   * Handle requests to get the current value of the "Rotation Speed" characteristic
+   */
+  async handleRotationSpeedGet() {
+    let currentValue = this.fanMode.Auto.rotation;
+    // set this to a valid value for RotationSpeed
+    await SamsungAPI.getFanMode(this.accessory.context.device.deviceId, this.accessory.context.token)
+      .then((fanMode) => {
+        switch (fanMode) {
+          case this.fanMode.Auto.name: {
+            currentValue = this.fanMode.Auto.rotation;
+            break;
+          }
+          case this.fanMode.Low.name: {
+            currentValue = this.fanMode.Low.rotation;
+            break;
+          }
+          case this.fanMode.Medium.name: {
+            currentValue = this.fanMode.Medium.rotation;
+            break;
+          }
+          case this.fanMode.High.name: {
+            currentValue = this.fanMode.High.rotation;
+            break;
+          }
+          case this.fanMode.Turbo.name: {
+            currentValue = this.fanMode.Turbo.rotation;
+            break;
+          }
+        }
+
+        this.fanV2Service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+          .updateValue(currentValue);
+      }).then(() => this.handleTargetFanStateGet())
+      .catch((error) => {
+        this.platform.log.warn(error);
+      });
+
+    return currentValue;
+  }
+
+  /**
+   * Handle requests to set the "Rotation Speed" characteristic
+   */
+  async handleRotationSpeedSet(speed) {
+    if (await this.handleHeaterCoolerActiveGet() === this.platform.Characteristic.Active.INACTIVE) {
+      // If the heater cooler system is inactive but the rotation speed was changed, fan mode is desired
+      await SamsungAPI.setDeviceMode(this.accessory.context.device.deviceId, this.deviceMode.Fan, this.accessory.context.token);
+    } else if (await this.handleCurrentHeaterCoolerStateGet() === this.platform.Characteristic.CurrentHeaterCoolerState.IDLE) {
+      // The fan speed cannot be changed if the heater cooler system is idle. Reverting.
+      await this.handleRotationSpeedGet();
+      return;
+    }
+
+    let modeValue = this.fanMode.Auto.name;
+    switch (speed) {
+      case 0: {
+        // If the target rotation speed is set to 0, the device should be turned off
+        return this.handleFanActiveSet(this.platform.Characteristic.Active.INACTIVE);
+      }
+      case this.fanMode.Low.rotation: {
+        modeValue = this.fanMode.Low.name;
+        break;
+      }
+      case this.fanMode.Medium.rotation: {
+        modeValue = this.fanMode.Medium.name;
+        break;
+      }
+      case this.fanMode.High.rotation: {
+        modeValue = this.fanMode.High.name;
+        break;
+      }
+      case this.fanMode.Turbo.rotation: {
+        modeValue = this.fanMode.Turbo.name;
+        break;
+      }
+    }
+
+    if (modeValue !== this.fanMode.Auto.name) {
+      // The fan speed indicates that manual mode is desired
+      this.fanV2Service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+        .updateValue(this.platform.Characteristic.TargetFanState.MANUAL);
+    }
+    SamsungAPI.setFanMode(this.accessory.context.device.deviceId, modeValue, this.accessory.context.token)
+      // After changing the fan mode, we definitely know that the fan is active
+      .then(() => this.handleFanActiveSet(this.platform.Characteristic.Active.ACTIVE));
+  }
+
+  /**
+   * Handle requests to get the current value of the "Target Fan State" characteristic
+   */
+  async handleTargetFanStateGet() {
+    let currentValue = this.platform.Characteristic.TargetFanState.AUTO;
+    // set this to a valid value for TargetFanState
+    await SamsungAPI.getFanMode(this.accessory.context.device.deviceId, this.accessory.context.token)
+      .then((fanMode) => {
+        if (fanMode === this.fanMode.Auto.name) {
+          currentValue = this.platform.Characteristic.TargetFanState.AUTO;
+        } else {
+          currentValue = this.platform.Characteristic.TargetFanState.MANUAL;
+        }
+
+        this.fanV2Service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+          .updateValue(currentValue);
+      }).catch((error) => {
+        this.platform.log.warn(error);
+      });
+
+    return currentValue;
+  }
+
+  /**
+   * Handle requests to set the "Target Fan State" characteristic
+   */
+  async handleTargetFanStateSet(value) {
+    if (await this.handleHeaterCoolerActiveGet() === this.platform.Characteristic.Active.INACTIVE) {
+      // The fan cannot be set to "auto" if the heater cooler system is not active.
+      this.fanV2Service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+        .updateValue(this.platform.Characteristic.TargetFanState.MANUAL);
+      return;
+    }
+
+    let modeValue: string;
+    if (value === this.platform.Characteristic.TargetFanState.MANUAL) {
+      modeValue = this.fanMode.Medium.name;
+      this.fanV2Service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+        .updateValue(this.fanMode.Medium.rotation);
+    } else {
+      modeValue = this.fanMode.Auto.name;
+      this.fanV2Service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+        .updateValue(this.fanMode.Auto.rotation);
+    }
+    await SamsungAPI.setFanMode(this.accessory.context.device.deviceId, modeValue, this.accessory.context.token);
+  }
+
+  /**
+   * Handle requests to get the current value of the "Swing Mode" characteristic
+   */
+  async handleSwingModeGet() {
+    let currentValue = this.platform.Characteristic.SwingMode.SWING_ENABLED;
+    // set this to a valid value for SwingMode
+    await SamsungAPI.getFanOscillationMode(this.accessory.context.device.deviceId, this.accessory.context.token)
+      .then((fanOscillationMode) => {
+        if (fanOscillationMode === this.swingMode.Fixed) {
+          // Other values for `fanOscillationMode` are possible but are not represented in HomeKit
+          currentValue = this.platform.Characteristic.SwingMode.SWING_DISABLED;
+        }
+
+        this.fanV2Service.getCharacteristic(this.platform.Characteristic.SwingMode)
+          .updateValue(currentValue);
+
+      }).catch((error) => {
+        this.platform.log.warn(error);
+      });
+
+    return currentValue;
+  }
+
+  /**
+   * Handle requests to set the "Swing Mode" characteristic
+   */
+  async handleSwingModeSet(value) {
+    const statusValue = value === 1 ? this.swingMode.All : this.swingMode.Fixed ;
+    await SamsungAPI.setFanOscillationMode(this.accessory.context.device.deviceId, statusValue, this.accessory.context.token);
   }
 
   private static toCelsius(fTemperature) {

--- a/src/samsungApi.ts
+++ b/src/samsungApi.ts
@@ -59,6 +59,54 @@ export class SamsungAPI {
     await Axios.post(`${HOST}/${deviceId}/commands`, data, this.setToken(token));
   }
 
+  static async getFanMode(deviceId, token) {
+    const {
+      data: { fanMode = { } } = {},
+    } = await Axios.get(`${HOST}/${deviceId}/components/main/capabilities/airConditionerFanMode/status`, this.setToken(token));
+    return fanMode.value;
+  }
+
+  static async setFanMode(deviceId, mode, token) {
+    // possible values: 'auto', 'low', 'medium', 'high', 'turbo'
+    const data = {
+      'commands' : [{'capability': 'airConditionerFanMode', 'command': 'setFanMode', 'arguments': [mode]}],
+    };
+
+    await Axios.post(`${HOST}/${deviceId}/commands`, data, this.setToken(token));
+  }
+
+  static async getFanOscillationMode(deviceId, token) {
+    const {
+      data: { fanOscillationMode = { } } = {},
+    } = await Axios.get(`${HOST}/${deviceId}/components/main/capabilities/fanOscillationMode/status`, this.setToken(token));
+    return fanOscillationMode.value;
+  }
+
+  static async setFanOscillationMode(deviceId, mode, token) {
+    // possible values: 'all', 'fixed', 'vertical', 'horizontal', 'indirect', 'direct', 'fixedCenter', 'fixedLeft', 'fixedRight', 'far'
+    const data = {
+      'commands' : [{'capability': 'fanOscillationMode', 'command': 'setFanOscillationMode', 'arguments': [mode]}],
+    };
+
+    await Axios.post(`${HOST}/${deviceId}/commands`, data, this.setToken(token));
+  }
+
+  static async getWindFreeMode(deviceId, token) {
+    const {
+      data: { acOptionalMode = { } } = {},
+    } = await Axios.get(`${HOST}/${deviceId}/components/main/capabilities/custom.airConditionerOptionalMode/status`, this.setToken(token));
+    return acOptionalMode.value;
+  }
+
+  static async setWindFreeMode(deviceId, mode, token) {
+    // possible values: 'off', 'windFree'
+    const data = {
+      'commands' : [{'capability': 'custom.airConditionerOptionalMode', 'command': 'setAcOptionalMode', 'arguments': [mode]}],
+    };
+
+    await Axios.post(`${HOST}/${deviceId}/commands`, data, this.setToken(token));
+  }
+
   static async getDesiredTemperature(deviceId, token) {
     const {
       data: { coolingSetpoint = { } } = {},

--- a/src/samsungApi.ts
+++ b/src/samsungApi.ts
@@ -36,6 +36,13 @@ export class SamsungAPI {
     return temperature.value;
   }
 
+  static async getDeviceHumidity(deviceId, token) {
+    const {
+      data: { humidity = { } } = {},
+    } = await Axios.get(`${HOST}/${deviceId}/components/main/capabilities/relativeHumidityMeasurement/status`, this.setToken(token));
+    return humidity.value;
+  }
+
   static async getDeviceMode(deviceId, token) {
     const {
       data: { airConditionerMode = { } } = {},

--- a/src/samsungApi.ts
+++ b/src/samsungApi.ts
@@ -1,8 +1,9 @@
 import Axios from 'axios';
 
 const AC_DEVICE_NAME = '[room a/c] Samsung';
-
 const HOST = 'https://api.smartthings.com/v1/devices';
+
+// Samsung API documentation: https://developer-preview.smartthings.com/docs/devices/capabilities/capabilities-reference/
 export class SamsungAPI {
   static setToken(token) {
     return { headers: { Authorization: `Bearer ${token}` } };
@@ -20,6 +21,7 @@ export class SamsungAPI {
   }
 
   static async setDeviceStatus(deviceId, status, token) {
+    // possible values: 'on', 'off'
     const data = {
       'commands' : [{'capability': 'switch', 'command': status}],
     };
@@ -42,6 +44,7 @@ export class SamsungAPI {
   }
 
   static async setDeviceMode(deviceId, mode, token) {
+    // possible modes: 'auto', 'dry', 'cool', 'heat', 'wind'
     const data = {
       'commands' : [{'capability': 'airConditionerMode', 'command': 'setAirConditionerMode', 'arguments': [mode]}],
     };
@@ -57,6 +60,7 @@ export class SamsungAPI {
   }
 
   static async setDesiredTemperature(deviceId, temperature, token) {
+    // data type: integer
     const data = {
       'commands' : [{'capability': 'thermostatCoolingSetpoint', 'command': 'setCoolingSetpoint', 'arguments': [temperature]}],
     };


### PR DESCRIPTION
Many thanks for this awesome plugin that works pretty reliable with current Samsung Air Conditioner models and uses the SmartThings API. Compared to other plugins I checked previously, it was much easier to understand.  
When checking the features of the plugin, I was interested in controlling the fan (and especially the WindFree mode) as well. As these features were not supported yet, I added basic functionality for these. All changes are described in the ReadMe and are split into dedicated commits.

## New features (taken from the ReadMe)

- Turning the fan on and off
- Getting and setting fan operation mode (manual / automatic)
- Getting and setting rotation speed of the fan 
  - A target fan speed of automatic will report with a rotation speed of 0% as the actual rotation speed cannot be determined.
- Getting and setting oscillation mode
- Getting and setting WindFree mode (if supported)
- Getting current humidity (if enabled)

## What does this MR change?

- Registers three different services ([heater cooler service](https://developers.homebridge.io/#/service/HeaterCooler), [fan v2 service](https://developers.homebridge.io/#/service/Fanv2), and [humidity sensor service](https://developers.homebridge.io/#/service/HumiditySensor)) in total
- Adds the following characteristics to the [fan v2 service](https://developers.homebridge.io/#/service/Fanv2): 
  - [Active](https://developers.homebridge.io/#/characteristic/Active) (Get/Set)
  - [Rotation Speed](https://developers.homebridge.io/#/characteristic/RotationSpeed) (Get/Set)
  - [Current Fan State](https://developers.homebridge.io/#/characteristic/CurrentFanState) (Get)
  - [Target Fan State](https://developers.homebridge.io/#/characteristic/TargetFanState) (Get/Set)
  - [Swing Mode](https://developers.homebridge.io/#/characteristic/SwingMode) (Get/Set)
- Adds the following characteristics to the [humidity sensor service](https://developers.homebridge.io/#/service/HumiditySensor): 
  - [Current Relative Humidity](https://developers.homebridge.io/#/characteristic/CurrentRelativeHumidity) (Get)
- Renames the existing service and temperature properties of the heater cooler service
- Introduction of two plugin-wide settings to enable support for the WindFree mode and humidity sensor

## Decisions / Choices I made

- The heater cooler is shown as "off" if _only_ the fan is operating. In my opinion, this is useful to determine whether the device is actually cooling, heating, or only blowing air.
- When the heater cooler or fan is powered off (`Active` is set to `off for any of these services), the device turns off. For turning on, the exact service defines the operation mode: 
  - If the fan is turned on, the device will be set to the "wind" mode without heating or cooling and just blowing air.
  - If the heater cooler is turned on, the device will resume in the previous operation mode or switch to "auto" if only the fan was previously active.
- The humidity sensor is showing a value of 0% if the device is not operating in A/C mode or just started a few moments ago. This is a limitation introduced by the device or SmartThings API. A possible improvement would be to hide the value/service if no reliable measurement is returned through the API.
- Move the fan oscillation mode settings to the heater cooler service if WindFree mode support is enabled to ease the use of the WindFree mode in Apple Home: When the fan and heater cooler services are grouped in one tile in Apple Home, only the fan oscillation mode is _directly_ accessible. As this mode is probably used more often with WindFree devices, this action replaces normal oscillation settings for these devices.
- The rotation speed is displayed with 0% if the fan mode is set to "automatic". Due to a limitation of the SmartThings API, the current fan speed cannot be retrieved and a "dummy" value needs to be chosen.
- All methods are marked as `async` and return a Promise to be handled by Homebridge or another method within this plugin. While doing so resolves some race conditions and enhances code readability, Homebridge might occasionally display a warning that this plugin slows down Homebridge on slow hardware (such as a first-generation Raspberry Pi).
- Some API calls to the SmartThings API work unreliably immediately after a related change. For example, when the fan mode is switched from "automatic" to "manual" (and acknowledged by the SmartThings API), the rotation speed might be still returned as "auto" for a few seconds from the SmartThings API. By manual testing, I found out that in this case, the rotation speed will be set to "low" which is also set in the code. This behavior is rather a workaround and could be fixed by (some intelligent) polling mechanism or dedicated event listener for the SmartThings API.

## Screenshots (click to expand)

<details>
<summary>Screenshot A/C Control</summary>

![IMG_1733](https://user-images.githubusercontent.com/7300329/147797726-9917f4f3-9dd1-4b05-b189-0db4498f51f6.PNG)

</details>
<details>
<summary>Screenshot A/C Details</summary>

![IMG_1734](https://user-images.githubusercontent.com/7300329/147797730-370fcc7a-7fe0-4875-a885-41e7dae91b9d.PNG)

</details>
<details>
<summary>Screenshot Fan Control</summary>

![IMG_1735](https://user-images.githubusercontent.com/7300329/147797734-1174a4b7-51f2-40f9-ac94-9958ea980bd4.PNG)

</details>
<details>
<summary>Screenshot Fan Details</summary>

![IMG_1736](https://user-images.githubusercontent.com/7300329/147797736-7013752b-6dfd-454b-9688-6bc44a07593d.PNG)

</details>

## Final remarks

I developed and tested the plugin thought the past few days extensively and am currently not aware of major bugs or limitations besides these noted above. Still, I have to admit that the plugin hasn't been used much in regular operation yet (an air conditioner is not that much used during the winter period). The most difficult part was reporting the correct fan rotation speed as it might change with other operation modes and settings when using the device. Hopefully, I caught all edge cases there...