### PR TITLE
Fix device discovery.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -11,6 +11,13 @@
         "required": true,
         "default": "homebridge-samsung-air-conditioner-smart-things"
       },
+      "deviceName": {
+        "title": "Device Name",
+        "description": "Device name as specified in the SmartThings app.",
+        "type": "string",
+        "required": false,
+        "default": ""
+      },
       "token": {
         "title": "Token",
         "type": "string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-samsung-air-conditioner-smart-things",
-  "version": "1.0.8",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Homebridge Samsung Air Conditioner Smartthings",
   "name": "homebridge-samsung-air-conditioner-smart-things",
-  "version": "1.1",
+  "version": "1.1.1",
   "description": "Homebridge plugin for controlling Samsung Air Conditioner using the smartthings api.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Homebridge Samsung Air Conditioner Smartthings",
   "name": "homebridge-samsung-air-conditioner-smart-things",
-  "version": "1.0.9",
+  "version": "1.1",
   "description": "Homebridge plugin for controlling Samsung Air Conditioner using the smartthings api.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -31,7 +31,7 @@ export class SamsungAC implements DynamicPlatformPlugin {
   }
 
   discoverDevices() {
-    SamsungAPI.getDevices(this.config.token).then(samsungDevices => {
+    SamsungAPI.getDevices({ config: this.config, logger: this.log }).then(samsungDevices => {
       for (const device of samsungDevices) {
         const uuid = this.api.hap.uuid.generate(device.deviceId.toString());
 

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -73,8 +73,8 @@ export class SamsungACPlatformAccessory {
       .onGet(this.handleCurrentTemperatureGet.bind(this));
 
     const temperatureProps = {
-      minValue: 16,
-      maxValue: 30,
+      minValue: 10, // C = 50 F
+      maxValue: 30, // C = 86 F
       minStep: 1,
     };
 
@@ -428,8 +428,8 @@ export class SamsungACPlatformAccessory {
           }
         }).then((activeModeAC) => {
           if (activeModeAC === undefined) {
-          // The fan is already active and the previous Promise did not return a new Promise
-          // Nothing should be changed here, skipping the actions below
+            // The fan is already active and the previous Promise did not return a new Promise
+            // Nothing should be changed here, skipping the actions below
             return;
           } else if (activeModeAC === this.platform.Characteristic.Active.INACTIVE) {
             SamsungAPI.setDeviceMode(this.accessory.context.device.deviceId, this.deviceMode.Fan, this.accessory.context.token);
@@ -667,15 +667,15 @@ export class SamsungACPlatformAccessory {
    * Handle requests to set the "Swing Mode" characteristic
    */
   async handleSwingModeSet(value) {
-    const statusValue = value === 1 ? this.swingMode.All : this.swingMode.Fixed ;
+    const statusValue = value === 1 ? this.swingMode.All : this.swingMode.Fixed;
     await SamsungAPI.setFanOscillationMode(this.accessory.context.device.deviceId, statusValue, this.accessory.context.token);
   }
 
   private static toCelsius(fTemperature) {
-    return Math.round((5/9) * (fTemperature - 32));
+    return Math.round((5 / 9) * (fTemperature - 32));
   }
 
-  private static toFahrenheit(cTemperature){
+  private static toFahrenheit(cTemperature) {
     return Math.round((cTemperature * 1.8) + 32);
   }
 }


### PR DESCRIPTION
I guess maybe Samsung changed the name they return for these, which is what is breaking it for people (including me). 

I changed to match on `deviceTypeName` as it seems that would be less mutable. However, I also added matching based on the `label`, which is what we customers name it in the app. This allows users of the plugin to specify the specific name of their device in case the type name matching fails in future (won't require another code change/plugin update). 

And included some logging around device discovery to help folks identify there's a problem here (or not). 

Oh, also reduced the minimum temp, because I actually set mine to 56 at night. No reason I can see not to support lower. 